### PR TITLE
🐛 fix: カラーバーの値範囲が機能していない問題を修正

### DIFF
--- a/src/controller/plot_controller.py
+++ b/src/controller/plot_controller.py
@@ -64,7 +64,9 @@ class PlotController:
             # プロットの更新
             self.app_controller.main_window.plot_panel.plot_heatmap(
                 x_data, y_data, z_data,
-                x_label, y_label
+                x_label, y_label,
+                vmin=self.value_range[0] if self.value_range else None,
+                vmax=self.value_range[1] if self.value_range else None
             )
 
             # 範囲の設定


### PR DESCRIPTION
Close #14
> 
> ## 変更内容
> - plot_panel.pyのplot_heatmapメソッドにvmin/vmaxパラメータを追加
> - plot_controller.pyの_update_plotメソッドで値範囲を適用
> - カラーマップ変更時とスケール変更時に値範囲を保持するように修正
> 
> ## 動作確認項目
> - [ ] 値範囲を設定すると、カラーバーの範囲が変更される
> - [ ] カラーマップを変更しても、設定した値範囲が保持される
> - [ ] スケール（線形/対数）を変更しても、設定した値範囲が保持される
> - [ ] 対数スケール時に0以下の値が適切に処理される

