### PR TITLE
fix: GitHub Actions release permission

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
     types: [ closed ]
+
+permissions:
+  contents: write
     
 jobs:
   build:


### PR DESCRIPTION
Closes #21

GitHub Actionsのリリース作成時に403エラーが発生する問題を修正します。

## 修正内容
- ワークフローファイルに `permissions: contents: write` を追加し、リリース作成の権限を付与

## 期待される結果
- PRマージ時にGitHub Actionsでリリースが正常に作成される