### PR TITLE
Add 3D color plot functionality

### DIFF
--- a/src/controller/app_controller.py
+++ b/src/controller/app_controller.py
@@ -182,6 +182,8 @@ class AppController:
         """
         # プロットパネルにカラーマップを設定
         self.main_window.plot_panel.set_colormap(colormap)
+        if hasattr(self.main_window, 'plot_3d_panel'):
+            self.main_window.plot_3d_panel.set_colormap(colormap)
 
     def set_scale(self, log_scale):
         """
@@ -255,21 +257,85 @@ class AppController:
         # ステータスバーの更新
         self.update_status("表示をリセットしました。")
 
+    def set_plot_mode(self, mode):
+        """
+        表示モードの設定
+
+        Args:
+            mode (str): 表示モード（'2d'または'3d'）
+        """
+        # プロットコントローラーに通知
+        self.plot_controller.set_plot_mode(mode)
+
+    def set_3d_axes(self, x_column, y_column, z_column, color_column=None):
+        """
+        3D表示用の軸とカラー値の設定
+
+        Args:
+            x_column (str): X軸に表示する列名
+            y_column (str): Y軸に表示する列名
+            z_column (str): Z軸（高さ）に表示する列名
+            color_column (str, optional): カラー値として表示する列名
+        """
+        # プロットコントローラーに通知
+        self.plot_controller.set_3d_axes(x_column, y_column, z_column, color_column)
+
+    def set_wireframe(self, wireframe):
+        """
+        ワイヤーフレーム表示の設定
+
+        Args:
+            wireframe (bool): ワイヤーフレーム表示の場合はTrue
+        """
+        # プロットコントローラーに通知
+        self.plot_controller.set_wireframe(wireframe)
+
+    def set_view_angle(self, elevation, azimuth):
+        """
+        視点角度の設定
+
+        Args:
+            elevation (float): 仰角（度）
+            azimuth (float): 方位角（度）
+        """
+        # プロットコントローラーに通知
+        self.plot_controller.set_view_angle(elevation, azimuth)
+
     def _update_plot(self):
         """プロットの更新"""
-        # ヒートマップデータの取得
         try:
-            x_data, y_data, z_data = self.data_processor.get_heatmap_data()
+            # 現在の表示モードを取得
+            plot_mode = self.plot_controller.plot_mode
 
-            # 軸ラベルの取得
-            x_label = self.main_window.control_panel.x_column.get()
-            y_label = self.main_window.control_panel.y_column.get()
+            if plot_mode == "3d":
+                # 3Dプロットの更新
+                # 3D表示用のデータを取得
+                x_data, y_data, z_data, c_data = self.data_processor.get_3d_plot_data()
 
-            # プロットの更新
-            self.main_window.plot_panel.plot_heatmap(
-                x_data, y_data, z_data,
-                x_label, y_label
-            )
+                # 軸ラベルの取得
+                x_label = self.main_window.control_panel.x_column.get()
+                y_label = self.main_window.control_panel.y_column.get()
+                z_label = self.main_window.control_panel.z_column.get()
+                c_label = self.main_window.control_panel.color_column.get()
+
+                # 3Dプロットの更新
+                self.main_window.plot_3d_panel.plot_3d_surface(
+                    x_data, y_data, z_data, c_data,
+                    x_label, y_label, z_label, c_label
+                )
+            else:
+                # 2Dプロットの更新
+                x_data, y_data, z_data = self.data_processor.get_heatmap_data()
+
+                # 軸ラベルの取得
+                x_label = self.main_window.control_panel.x_column.get()
+                y_label = self.main_window.control_panel.y_column.get()
+
+                # プロットの更新
+                self.main_window.plot_panel.plot_heatmap(
+                    x_data, y_data, z_data,
+                    x_label, y_label
+                )
 
             # 範囲の取得
             x_range = self.data_processor.get_axis_range('x')

--- a/src/controller/plot_controller.py
+++ b/src/controller/plot_controller.py
@@ -28,6 +28,65 @@ class PlotController:
         self.y_range = None
         self.value_range = None
         self.profile_window = None  # 断面プロットウィンドウの参照
+        self.plot_mode = "2d"      # 表示モード（'2d'または'3d'）
+
+    def set_plot_mode(self, mode):
+        """
+        表示モードの設定
+
+        Args:
+            mode (str): 表示モード（'2d'または'3d'）
+        """
+        # メインウィンドウの表示モードを切り替え
+        self.app_controller.main_window.set_plot_mode(mode)
+        
+        # 現在のモードを記録
+        self.plot_mode = mode
+        
+        # プロットの更新
+        self._update_plot()
+
+    def set_3d_axes(self, x_column, y_column, z_column, color_column=None):
+        """
+        3D表示用の軸とカラー値の設定
+
+        Args:
+            x_column (str): X軸に表示する列名
+            y_column (str): Y軸に表示する列名
+            z_column (str): Z軸（高さ）に表示する列名
+            color_column (str, optional): カラー値として表示する列名
+        """
+        try:
+            # データプロセッサーに3D軸を設定
+            self.app_controller.data_processor.set_3d_axes(
+                x_column, y_column, z_column, color_column
+            )
+            
+            # プロットの更新
+            self._update_plot()
+        except Exception as e:
+            self.app_controller.show_error("軸設定エラー", str(e))
+
+    def set_wireframe(self, wireframe):
+        """
+        ワイヤーフレーム表示の設定
+
+        Args:
+            wireframe (bool): ワイヤーフレーム表示の場合はTrue
+        """
+        # 3Dプロットパネルにワイヤーフレーム設定を適用
+        self.app_controller.main_window.plot_3d_panel.set_wireframe(wireframe)
+
+    def set_view_angle(self, elevation, azimuth):
+        """
+        視点角度の設定
+
+        Args:
+            elevation (float): 仰角（度）
+            azimuth (float): 方位角（度）
+        """
+        # 3Dプロットパネルに視点角度を設定
+        self.app_controller.main_window.plot_3d_panel.set_view_angle(elevation, azimuth)
 
     def set_ranges(self, x_range, y_range, value_range):
         """
@@ -56,6 +115,14 @@ class PlotController:
 
     def _update_plot(self):
         """プロットの更新"""
+        # 現在の表示モードに応じてプロットを更新
+        if self.plot_mode == "3d":
+            self._update_3d_plot()
+        else:
+            self._update_2d_plot()
+
+    def _update_2d_plot(self):
+        """2Dプロットの更新"""
         # データプロセッサーからデータを取得
         try:
             x_data, y_data, z_data = self.app_controller.data_processor.get_heatmap_data()
@@ -79,7 +146,28 @@ class PlotController:
                 self.app_controller.main_window.plot_panel.canvas.draw()
 
         except Exception as e:
-            self.app_controller.show_error("プロット更新エラー", str(e))
+            self.app_controller.show_error("2Dプロット更新エラー", str(e))
+
+    def _update_3d_plot(self):
+        """3Dプロットの更新"""
+        # データプロセッサーからデータを取得
+        try:
+            x_data, y_data, z_data, c_data = self.app_controller.data_processor.get_3d_plot_data()
+
+            # 軸ラベルの取得
+            x_label = self.app_controller.main_window.control_panel.x_column.get()
+            y_label = self.app_controller.main_window.control_panel.y_column.get()
+            z_label = self.app_controller.main_window.control_panel.z_column.get()
+            c_label = self.app_controller.main_window.control_panel.color_column.get()
+
+            # プロットの更新
+            self.app_controller.main_window.plot_3d_panel.plot_3d_surface(
+                x_data, y_data, z_data, c_data,
+                x_label, y_label, z_label, c_label
+            )
+
+        except Exception as e:
+            self.app_controller.show_error("3Dプロット更新エラー", str(e))
 
     def update_plot_ranges(self, x_range, y_range):
         """

--- a/src/model/data_processor.py
+++ b/src/model/data_processor.py
@@ -351,6 +351,128 @@ class DataProcessor:
 
         return result
 
+    def set_3d_axes(self, x_column: str, y_column: str, z_column: str, color_column: str = None) -> None:
+        """
+        3D表示用の軸とカラー値の列を設定します。
+
+        Args:
+            x_column (str): X軸に表示する列名
+            y_column (str): Y軸に表示する列名
+            z_column (str): Z軸（高さ）に表示する列名
+            color_column (str, optional): カラー値として表示する列名（省略時はz_columnと同じ）
+        """
+        if self.data is None:
+            raise ValueError("データが設定されていません。")
+
+        # 列の存在チェック
+        for col, label in [(x_column, "X軸"), (y_column, "Y軸"), (z_column, "Z軸")]:
+            if col not in self.data.columns:
+                raise ValueError(f"{label}の列 '{col}' がデータに存在しません。")
+
+        # カラー列が指定されている場合はチェック
+        if color_column and color_column not in self.data.columns:
+            raise ValueError(f"カラー値の列 '{color_column}' がデータに存在しません。")
+
+        # 軸が変更された場合はキャッシュを無効化
+        if (hasattr(self, 'z_column') and self.z_column != z_column) or \
+           (hasattr(self, 'color_column') and self.color_column != color_column):
+            self._invalidate_cache()
+
+        # 3D表示用の列を設定
+        self.z_column = z_column
+        self.color_column = color_column if color_column else z_column
+
+        # 2D表示用の列も更新（X軸とY軸は共通）
+        self.set_axes(x_column, y_column, self.color_column)
+
+    def get_3d_plot_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        3Dプロット表示用のデータを取得します。
+        NumPyのベクトル化処理とキャッシュを使用して高速化しています。
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: (X軸の値, Y軸の値, Z軸の値, カラー値)
+        """
+        if self.processed_data is None or len(self.processed_data) == 0:
+            raise ValueError("処理済みデータが存在しません。")
+
+        if not hasattr(self, 'z_column') or not hasattr(self, 'color_column'):
+            raise ValueError("3D表示用の軸が設定されていません。")
+
+        # キャッシュキーの生成
+        cache_key = self._get_cache_key("3d_plot")
+
+        # キャッシュにデータがある場合はそれを返す
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        # ユニークなX軸、Y軸の値を取得（ソート済み）
+        x_values = np.array(sorted(self.processed_data[self.x_column].unique()))
+        y_values = np.array(sorted(self.processed_data[self.y_column].unique()))
+
+        # メッシュグリッドの作成
+        X, Y = np.meshgrid(x_values, y_values)
+
+        # Z値とカラー値の初期化（NaNで埋める）
+        Z = np.full(X.shape, np.nan)
+        C = np.full(X.shape, np.nan)
+
+        # データポイントをマッピング（ベクトル化処理）
+        x_data = self.processed_data[self.x_column].values
+        y_data = self.processed_data[self.y_column].values
+        z_data = self.processed_data[self.z_column].values
+        c_data = self.processed_data[self.color_column].values
+
+        # x値とy値のインデックスを高速に検索するための辞書を作成
+        x_indices = {val: i for i, val in enumerate(x_values)}
+        y_indices = {val: i for i, val in enumerate(y_values)}
+
+        # 各データポイントのインデックスを取得
+        x_idx = np.array([x_indices.get(x, -1) for x in x_data])
+        y_idx = np.array([y_indices.get(y, -1) for y in y_data])
+
+        # 有効なインデックスのみを使用してZ値とカラー値を設定
+        valid_indices = (x_idx >= 0) & (y_idx >= 0)
+        Z[y_idx[valid_indices], x_idx[valid_indices]] = z_data[valid_indices]
+        C[y_idx[valid_indices], x_idx[valid_indices]] = c_data[valid_indices]
+
+        # 結果をキャッシュに保存
+        result = (X, Y, Z, C)
+        self._cache[cache_key] = result
+
+        return result
+
+    def _downsample_data(self, x_data: np.ndarray, y_data: np.ndarray, z_data: np.ndarray, c_data: np.ndarray, max_points: int = 10000) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        大規模データセットを間引きして表示を最適化します。
+
+        Args:
+            x_data (np.ndarray): X軸のデータ
+            y_data (np.ndarray): Y軸のデータ
+            z_data (np.ndarray): Z軸のデータ
+            c_data (np.ndarray): カラー値のデータ
+            max_points (int): 最大表示ポイント数
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: 間引き後のデータ
+        """
+        total_points = x_data.size
+        
+        # データポイント数が上限を超える場合は間引き
+        if total_points > max_points:
+            # 間引き率の計算
+            downsample_rate = int(np.ceil(total_points / max_points))
+            
+            # データの間引き
+            x_downsampled = x_data[::downsample_rate, ::downsample_rate]
+            y_downsampled = y_data[::downsample_rate, ::downsample_rate]
+            z_downsampled = z_data[::downsample_rate, ::downsample_rate]
+            c_downsampled = c_data[::downsample_rate, ::downsample_rate]
+            
+            return x_downsampled, y_downsampled, z_downsampled, c_downsampled
+        
+        return x_data, y_data, z_data, c_data
+
     def get_axis_range(self, axis: str) -> Tuple[float, float]:
         """
         指定された軸の値の範囲を取得します。

--- a/src/view/control_panel.py
+++ b/src/view/control_panel.py
@@ -273,6 +273,75 @@ class ControlPanel:
         separator = ttk.Separator(self.frame, orient=tk.HORIZONTAL)
         separator.pack(fill=tk.X, pady=5)
 
+        # 表示モードフレーム
+        display_mode_frame = ttk.LabelFrame(self.frame, text="表示モード")
+        display_mode_frame.pack(fill=tk.X, pady=5)
+
+        # 表示モード選択
+        self.display_mode = tk.StringVar(value="2d")
+        ttk.Radiobutton(display_mode_frame, text="2Dヒートマップ", variable=self.display_mode,
+                       value="2d", command=self._on_display_mode_change).pack(anchor=tk.W, padx=5, pady=2)
+        ttk.Radiobutton(display_mode_frame, text="3Dサーフェスプロット", variable=self.display_mode,
+                       value="3d", command=self._on_display_mode_change).pack(anchor=tk.W, padx=5, pady=2)
+
+        # 3D表示用の軸設定フレーム
+        self.axis_3d_frame = ttk.LabelFrame(self.frame, text="3D軸設定")
+        self.axis_3d_frame.pack(fill=tk.X, pady=5)
+        self.axis_3d_frame.pack_forget()  # 初期状態では非表示
+
+        # Z軸選択
+        self.z_column = tk.StringVar()
+        z_frame = ttk.Frame(self.axis_3d_frame)
+        z_frame.pack(fill=tk.X, pady=2)
+        ttk.Label(z_frame, text="Z軸:").pack(side=tk.LEFT, padx=5)
+        self.z_combo = ttk.Combobox(z_frame, textvariable=self.z_column, state="readonly")
+        self.z_combo.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=5)
+        self.z_combo.bind("<<ComboboxSelected>>", self._on_3d_axis_change)
+
+        # カラー値選択
+        self.color_column = tk.StringVar()
+        color_frame = ttk.Frame(self.axis_3d_frame)
+        color_frame.pack(fill=tk.X, pady=2)
+        ttk.Label(color_frame, text="カラー:").pack(side=tk.LEFT, padx=5)
+        self.color_combo = ttk.Combobox(color_frame, textvariable=self.color_column, state="readonly")
+        self.color_combo.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=5)
+        self.color_combo.bind("<<ComboboxSelected>>", self._on_3d_axis_change)
+
+        # 3D表示オプションフレーム
+        self.display_3d_options_frame = ttk.LabelFrame(self.frame, text="3D表示オプション")
+        self.display_3d_options_frame.pack(fill=tk.X, pady=5)
+        self.display_3d_options_frame.pack_forget()  # 初期状態では非表示
+
+        # ワイヤーフレーム表示
+        self.wireframe = tk.BooleanVar(value=False)
+        wireframe_check = ttk.Checkbutton(self.display_3d_options_frame, text="ワイヤーフレーム表示",
+                                        variable=self.wireframe, command=self._on_wireframe_change)
+        wireframe_check.pack(anchor=tk.W, padx=5, pady=2)
+
+        # 視点角度設定
+        view_frame = ttk.Frame(self.display_3d_options_frame)
+        view_frame.pack(fill=tk.X, pady=2)
+
+        # 仰角
+        elev_frame = ttk.Frame(view_frame)
+        elev_frame.pack(fill=tk.X, pady=2)
+        ttk.Label(elev_frame, text="仰角:").pack(side=tk.LEFT, padx=5)
+        self.elevation = tk.DoubleVar(value=30.0)
+        elev_scale = ttk.Scale(elev_frame, from_=0, to=90, variable=self.elevation,
+                             orient=tk.HORIZONTAL, command=self._on_view_angle_change)
+        elev_scale.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=5)
+        ttk.Label(elev_frame, textvariable=self.elevation).pack(side=tk.LEFT, padx=5)
+
+        # 方位角
+        azim_frame = ttk.Frame(view_frame)
+        azim_frame.pack(fill=tk.X, pady=2)
+        ttk.Label(azim_frame, text="方位角:").pack(side=tk.LEFT, padx=5)
+        self.azimuth = tk.DoubleVar(value=-60.0)
+        azim_scale = ttk.Scale(azim_frame, from_=-180, to=180, variable=self.azimuth,
+                             orient=tk.HORIZONTAL, command=self._on_view_angle_change)
+        azim_scale.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=5)
+        ttk.Label(azim_frame, textvariable=self.azimuth).pack(side=tk.LEFT, padx=5)
+
         # 表示オプションフレーム
         display_frame = ttk.LabelFrame(self.frame, text="表示オプション")
         display_frame.pack(fill=tk.X, pady=5)
@@ -674,11 +743,80 @@ class ControlPanel:
         else:
             self.controller.update_status("断面表示モード: OFF")
 
+    def _on_display_mode_change(self):
+        """表示モード変更時の処理"""
+        mode = self.display_mode.get()
+        
+        # 2Dモードと3Dモードで表示するフレームを切り替え
+        if mode == "2d":
+            self.axis_3d_frame.pack_forget()
+            self.display_3d_options_frame.pack_forget()
+        else:  # 3dモード
+            self.axis_3d_frame.pack(after=self.axis_frame)
+            self.display_3d_options_frame.pack(after=self.display_frame)
+        
+        # コントローラーに通知
+        self.controller.set_plot_mode(mode)
+
+    def _on_3d_axis_change(self, event):
+        """3D軸変更時の処理"""
+        # コントローラーに通知
+        self.controller.set_3d_axes(
+            self.x_column.get(),
+            self.y_column.get(),
+            self.z_column.get(),
+            self.color_column.get()
+        )
+
+    def _on_wireframe_change(self):
+        """ワイヤーフレーム表示変更時の処理"""
+        # コントローラーに通知
+        self.controller.set_wireframe(self.wireframe.get())
+
+    def _on_view_angle_change(self, event=None):
+        """視点角度変更時の処理"""
+        # コントローラーに通知
+        self.controller.set_view_angle(self.elevation.get(), self.azimuth.get())
+
     def _on_reset(self):
         """リセット時の処理"""
         # 断面表示モードをOFFにする
         self.profile_mode.set(False)
         self._on_profile_mode_change()
 
+        # 3D表示モードをリセット
+        if self.display_mode.get() == "3d":
+            self.elevation.set(30.0)
+            self.azimuth.set(-60.0)
+            self.wireframe.set(False)
+            self._on_view_angle_change()
+            self._on_wireframe_change()
+
         # コントローラーに通知
         self.controller.reset_view()
+
+    def update_columns(self, columns):
+        """
+        列リストの更新
+
+        Args:
+            columns (list): 列名のリスト
+        """
+        self.columns = columns
+
+        # コンボボックスの更新
+        self.x_combo["values"] = columns
+        self.y_combo["values"] = columns
+        self.value_combo["values"] = columns
+        self.filter_combo["values"] = columns
+        self.z_combo["values"] = columns
+        self.color_combo["values"] = columns
+
+        # デフォルト値の設定
+        if len(columns) >= 3:
+            self.x_combo.current(0)
+            self.y_combo.current(1)
+            self.value_combo.current(2)
+            self.filter_combo.current(0)
+            self.z_combo.current(2)
+            self.color_combo.current(2)

--- a/src/view/main_window.py
+++ b/src/view/main_window.py
@@ -7,6 +7,7 @@
 from .status_bar import StatusBar
 from .control_panel import ControlPanel
 from .plot_panel import PlotPanel
+from .plot_3d_panel import Plot3DPanel
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import matplotlib
@@ -87,7 +88,23 @@ class MainWindow:
         # 各コンポーネントの作成
         self.control_panel = ControlPanel(self.control_frame, self.controller)
         self.plot_panel = PlotPanel(self.plot_frame, self.controller)
+        self.plot_3d_panel = Plot3DPanel(self.plot_frame, self.controller)
+        self.plot_3d_panel.frame.pack_forget()  # 初期状態では非表示
         self.status_bar = StatusBar(self.status_frame)
+
+    def set_plot_mode(self, mode):
+        """
+        表示モードの設定
+
+        Args:
+            mode (str): 表示モード（'2d'または'3d'）
+        """
+        if mode == "2d":
+            self.plot_3d_panel.frame.pack_forget()
+            self.plot_panel.frame.pack(fill=tk.BOTH, expand=True)
+        else:  # 3dモード
+            self.plot_panel.frame.pack_forget()
+            self.plot_3d_panel.frame.pack(fill=tk.BOTH, expand=True)
 
     def run(self):
         """アプリケーションの実行"""

--- a/src/view/plot_3d_panel.py
+++ b/src/view/plot_3d_panel.py
@@ -1,0 +1,223 @@
+"""
+3Dプロットパネルモジュール
+
+matplotlib.mplot3dを使用した3Dプロット表示を提供します。
+"""
+
+import tkinter as tk
+from tkinter import ttk
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+from mpl_toolkits.mplot3d import Axes3D
+import numpy as np
+import matplotlib
+matplotlib.use('TkAgg')
+
+
+class Plot3DPanel:
+    """
+    3Dプロットパネルクラス
+
+    matplotlib.mplot3dを使用した3Dプロット表示を提供します。
+    """
+
+    def __init__(self, parent, controller):
+        """
+        3Dプロットパネルの初期化
+
+        Args:
+            parent: 親ウィジェット
+            controller: アプリケーションコントローラー
+        """
+        self.parent = parent
+        self.controller = controller
+
+        # プロットの状態
+        self.data = None
+        self.x_data = None
+        self.y_data = None
+        self.z_data = None
+        self.c_data = None
+        self.colormap = 'plasma'  # デフォルトのカラーマップ
+        self.wireframe = False    # ワイヤーフレーム表示
+        self.surface = None       # サーフェスプロットの参照
+        self.colorbar = None      # カラーバーの参照
+
+        self._create_widgets()
+
+    def _create_widgets(self):
+        """ウィジェットの作成"""
+        # メインフレーム
+        self.frame = ttk.Frame(self.parent)
+        self.frame.pack(fill=tk.BOTH, expand=True)
+
+        # Figureの作成
+        self.figure = Figure(figsize=(6, 5), dpi=100)
+        self.ax = self.figure.add_subplot(111, projection='3d')
+
+        # キャンバスの作成
+        self.canvas = FigureCanvasTkAgg(self.figure, self.frame)
+        self.canvas.draw()
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+        # ツールバーの作成
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self.frame)
+        self.toolbar.update()
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+        # マウスイベントの設定
+        self.canvas.mpl_connect('motion_notify_event', self._on_motion)
+        self.canvas.mpl_connect('button_press_event', self._on_click)
+
+    def plot_3d_surface(self, x_data, y_data, z_data, c_data=None, x_label=None, y_label=None, z_label=None, c_label=None, title=None):
+        """
+        3Dサーフェスプロットの描画
+
+        Args:
+            x_data (numpy.ndarray): X軸のデータ
+            y_data (numpy.ndarray): Y軸のデータ
+            z_data (numpy.ndarray): Z軸のデータ（高さ）
+            c_data (numpy.ndarray, optional): カラーマップの値（省略時はz_dataを使用）
+            x_label (str, optional): X軸のラベル
+            y_label (str, optional): Y軸のラベル
+            z_label (str, optional): Z軸のラベル
+            c_label (str, optional): カラー値のラベル
+            title (str, optional): プロットのタイトル
+        """
+        self.x_data = x_data
+        self.y_data = y_data
+        self.z_data = z_data
+        self.c_data = c_data if c_data is not None else z_data
+
+        # Figureを完全にクリア
+        self.figure.clear()
+
+        # 新しいAxesを作成
+        self.ax = self.figure.add_subplot(111, projection='3d')
+
+        # 無効な値（NaN）を含む場合はマスク
+        mask = ~np.isnan(z_data)
+        if not np.any(mask):
+            self.ax.text(0.5, 0.5, 0.5, "有効なデータがありません", ha='center', va='center', transform=self.ax.transAxes)
+            self.canvas.draw()
+            return
+
+        # サーフェスプロットの描画
+        if self.wireframe:
+            # ワイヤーフレーム表示
+            self.surface = self.ax.plot_wireframe(
+                x_data, y_data, z_data,
+                rstride=1, cstride=1,
+                linewidth=0.5
+            )
+            # 別途カラーマップを表示
+            self.surface = self.ax.scatter(
+                x_data.flatten(), y_data.flatten(), z_data.flatten(),
+                c=self.c_data.flatten(),
+                cmap=self.colormap,
+                s=10
+            )
+        else:
+            # サーフェス表示
+            self.surface = self.ax.plot_surface(
+                x_data, y_data, z_data,
+                facecolors=matplotlib.cm.get_cmap(self.colormap)(
+                    (self.c_data - np.nanmin(self.c_data)) / (np.nanmax(self.c_data) - np.nanmin(self.c_data))
+                ),
+                rstride=1, cstride=1,
+                linewidth=0,
+                antialiased=True,
+                shade=True
+            )
+
+        # カラーバーの追加
+        norm = matplotlib.colors.Normalize(vmin=np.nanmin(self.c_data), vmax=np.nanmax(self.c_data))
+        sm = matplotlib.cm.ScalarMappable(cmap=self.colormap, norm=norm)
+        sm.set_array([])
+        self.colorbar = self.figure.colorbar(sm, ax=self.ax, label=c_label or '値')
+
+        # 軸ラベルの設定
+        self.ax.set_xlabel(x_label or 'X')
+        self.ax.set_ylabel(y_label or 'Y')
+        self.ax.set_zlabel(z_label or 'Z')
+
+        # タイトルの設定（指定があれば）
+        if title:
+            self.ax.set_title(title)
+
+        # キャンバスの更新
+        self.canvas.draw()
+
+    def set_colormap(self, colormap):
+        """
+        カラーマップの設定
+
+        Args:
+            colormap (str): カラーマップ名
+        """
+        self.colormap = colormap
+        if self.z_data is not None:
+            self.plot_3d_surface(
+                self.x_data, self.y_data, self.z_data, self.c_data,
+                self.ax.get_xlabel(), self.ax.get_ylabel(), self.ax.get_zlabel(),
+                self.colorbar.ax.get_ylabel() if self.colorbar else None,
+                self.ax.get_title()
+            )
+
+    def set_wireframe(self, wireframe):
+        """
+        ワイヤーフレーム表示の設定
+
+        Args:
+            wireframe (bool): ワイヤーフレーム表示の場合はTrue
+        """
+        self.wireframe = wireframe
+        if self.z_data is not None:
+            self.plot_3d_surface(
+                self.x_data, self.y_data, self.z_data, self.c_data,
+                self.ax.get_xlabel(), self.ax.get_ylabel(), self.ax.get_zlabel(),
+                self.colorbar.ax.get_ylabel() if self.colorbar else None,
+                self.ax.get_title()
+            )
+
+    def set_view_angle(self, elevation, azimuth):
+        """
+        視点角度の設定
+
+        Args:
+            elevation (float): 仰角（度）
+            azimuth (float): 方位角（度）
+        """
+        if self.ax:
+            self.ax.view_init(elev=elevation, azim=azimuth)
+            self.canvas.draw()
+
+    def _on_motion(self, event):
+        """
+        マウス移動時の処理
+
+        Args:
+            event: マウスイベント
+        """
+        if event.inaxes != self.ax:
+            return
+
+        # 3Dプロットではカーソル位置の値表示は複雑なため、
+        # 現在の視点角度を表示する
+        if hasattr(self.ax, 'elev') and hasattr(self.ax, 'azim'):
+            status_text = f"視点: 仰角={self.ax.elev:.1f}°, 方位角={self.ax.azim:.1f}°"
+            self.controller.update_status(status_text)
+
+    def _on_click(self, event):
+        """
+        マウスクリック時の処理
+
+        Args:
+            event: マウスイベント
+        """
+        if event.inaxes != self.ax:
+            return
+
+        # 右クリックの場合はリセット
+        if event.button == 3:
+            self.controller.reset_view()


### PR DESCRIPTION
Issue #36 の対応

## 変更内容
- 2次元ヒートマップに加えて3次元サーフェスプロットを表示する機能を追加
- X軸、Y軸、Z軸（高さ）、カラー値の4つのパラメータを設定可能に
- 3Dプロットの回転、ズーム、パンなどのインタラクティブな操作
- 3Dプロットの視点角度、ワイヤーフレーム表示などの設定

## 実装の詳細
- Plot3DPanel: matplotlib.mplot3dを使用した3Dプロット表示
- DataProcessor: 3D表示用のデータ処理とキャッシュ機能
- ControlPanel: 3D表示モードと設定UI
- PlotController: 3D表示の制御機能
- MainWindow: 2D/3Dモードの切り替え

## 動作確認項目
- [ ] 2D/3Dモードの切り替えが正常に動作すること
- [ ] 3Dプロットで4つのパラメータが正しく表示されること
- [ ] マウス操作による回転、ズーム、パンが機能すること
- [ ] 大規模データセットでも適切なパフォーマンスで動作すること